### PR TITLE
Deleted redundant checkstyle rule.

### DIFF
--- a/CPPL Checkstyle Rules.xml
+++ b/CPPL Checkstyle Rules.xml
@@ -154,7 +154,6 @@
         <module name="AvoidInlineConditionals"/>
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
-        <module name="HiddenField"/>
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
         <module name="MissingSwitchDefault"/>


### PR DESCRIPTION
We want to shadow field of classes in the constructor, so we deleted the interfering checkstyle rule.