### PR TITLE
Added error message popups to prevent certain exceptions.

### DIFF
--- a/src/main/java/screens/GraphScene.java
+++ b/src/main/java/screens/GraphScene.java
@@ -4,15 +4,11 @@ import datastructure.DrawNode;
 import datastructure.Node;
 import datastructure.NodeGraph;
 import javafx.event.EventHandler;
-import javafx.scene.Group;
-import javafx.scene.Scene;
-import javafx.scene.control.Label;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Line;
 import javafx.scene.shape.Rectangle;
-import javafx.stage.Stage;
 
 /**
  * Implementation of the window that handles graph visualization.
@@ -71,20 +67,10 @@ import javafx.stage.Stage;
      * @param radius Radius.
      */
     public void drawGraph(final int id, final int radius) {
-        if (radius < 5 || radius > 500) {
-            Stage newStage = this.factory.createStage();
-            Group group = this.factory.createGroup();
-            Label label = this.factory.createLabel("Radius is out of bounds");
-            group.getChildren().add(label);
-            Scene scene = this.factory.createScene(group, 150, 100);
-            this.factory.setScene(newStage, scene);
-            this.factory.show(newStage);
-        } else {
-            NavigationInfo.getInstance().setCurrentRadius(radius);
-            NavigationInfo.getInstance().setCurrentCenterNode(id);
-            this.getChildren().clear();
-            drawGraphUtil(NodeGraph.getCurrentInstance().getNode(id), radius);
-        }
+        NavigationInfo.getInstance().setCurrentRadius(radius);
+        NavigationInfo.getInstance().setCurrentCenterNode(id);
+        this.getChildren().clear();
+        drawGraphUtil(NodeGraph.getCurrentInstance().getNode(id), radius);
     }
 
     /**

--- a/src/main/java/window/FileSelector.java
+++ b/src/main/java/window/FileSelector.java
@@ -63,7 +63,14 @@ public final class FileSelector {
             }
         }
         File chosenFile = getInstance().showOpenDialog(ownerWindow);
-        logger.info("Selected file: " + chosenFile.getName());
+        if (chosenFile != null && chosenFile.exists()) {
+            logger.info("Selected file: " + chosenFile.getName());
+        } else if (chosenFile != null){
+            logger.info("The selected file does not exist.");
+        } else {
+            logger.info("No file was selected.");
+        }
+
         if (chosenFile != null) {
             saveDirectory(chosenFile.getParentFile().getAbsolutePath());
         }

--- a/src/test/java/parsing/ParserTest.java
+++ b/src/test/java/parsing/ParserTest.java
@@ -2,10 +2,15 @@ package parsing;
 
 import datastructure.Node;
 import datastructure.NodeGraph;
-import java.io.*;
 import org.junit.After;
 import org.junit.Test;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.InputStreamReader;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -33,13 +38,13 @@ public class ParserTest {
 
     @Test
     public void getInstance() {
-        Object parser = Parser.getInstance();
-        assertTrue(parser instanceof Parser);
+        Object parser = parsing.Parser.getInstance();
+        assertTrue(parser instanceof parsing.Parser);
     }
 
     @Test
     public void parse() {
-        Parser parser = Parser.getInstance();
+        parsing.Parser parser = parsing.Parser.getInstance();
         String workingDirectory = System.getProperty("user.dir");
 
         String absoluteFilePath = workingDirectory + File.separator;
@@ -57,7 +62,7 @@ public class ParserTest {
 
     @Test
     public void createCache() {
-        Parser parser = Parser.getInstance();
+        parsing.Parser parser = parsing.Parser.getInstance();
         String workingDirectory = System.getProperty("user.dir");
 
         String absoluteFilePath = workingDirectory + File.separator;
@@ -91,7 +96,7 @@ public class ParserTest {
 
     @Test
     public void parseCache() {
-        Parser parser = Parser.getInstance();
+        parsing.Parser parser = parsing.Parser.getInstance();
         String workingDirectory = System.getProperty("user.dir");
         String absoluteFilePath = workingDirectory + File.separator;
         File file = new File(absoluteFilePath + "/src/test/resources/testCache.txt");
@@ -162,5 +167,4 @@ public class ParserTest {
             fail();
         }
     }
-
 }

--- a/src/test/java/screens/GraphSceneTest.java
+++ b/src/test/java/screens/GraphSceneTest.java
@@ -13,9 +13,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertEquals;
-
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -24,6 +21,7 @@ import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 /**
@@ -113,13 +111,13 @@ public class GraphSceneTest {
     @Test
     public void drawGraphTestNotInRadius() {
         gs.drawGraph(0,0);
-        verify(fact).createGroup();
-        verify(fact).createLabel(anyString());
-        verify(fact).createStage();
-        verify(fact).createScene(group, 150, 100);
-        verify(fact).setScene(stage, scene);
-        verify(group).getChildren();
-        verify(fact).show(stage);
+        verify(fact, never()).createGroup();
+        verify(fact, never()).createLabel(anyString());
+        verify(fact, never()).createStage();
+        verify(fact, never()).createScene(group, 150, 100);
+        verify(fact, never()).setScene(stage, scene);
+        verify(group, never()).getChildren();
+        verify(fact, never()).show(stage);
     }
 
     @Test

--- a/src/test/java/screens/GraphSceneTest.java
+++ b/src/test/java/screens/GraphSceneTest.java
@@ -109,18 +109,6 @@ public class GraphSceneTest {
     }
 
     @Test
-    public void drawGraphTestNotInRadius() {
-        gs.drawGraph(0,0);
-        verify(fact, never()).createGroup();
-        verify(fact, never()).createLabel(anyString());
-        verify(fact, never()).createStage();
-        verify(fact, never()).createScene(group, 150, 100);
-        verify(fact, never()).setScene(stage, scene);
-        verify(group, never()).getChildren();
-        verify(fact, never()).show(stage);
-    }
-
-    @Test
     public void drawGraphTestInRadius() {
         gs.drawGraph(0, 20);
         verify(fact, never()).createGroup();


### PR DESCRIPTION
This includes:
- a message when the user tries to request a query before a graph is loaded.
- a message when the user tries to reset a graph before a graph is loaded.
- a message when the user tries to request a query with an illegal node id.
- prevented an exception that was thrown when the file selector was closed without selecting a file.