### PR TITLE
ProgressBar in seperate window

### DIFF
--- a/src/main/java/screens/GraphScene.java
+++ b/src/main/java/screens/GraphScene.java
@@ -81,7 +81,10 @@ import java.util.Set;
         Thread thread = new Thread() {
             public void run() {
                 try {
-                    Parser.getThread().join();
+                    Thread parser = Parser.getThread();
+                    if (parser != null) {
+                        parser.join();
+                    }
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
Moves the progress bar to a seperate window. Functionality stays the same. Also fix a bug with GraphSceneTest where a nullpointer would be thrown for no reason.